### PR TITLE
V9.0.2/package maintenance

### DIFF
--- a/.docfx/api/namespaces/Codebelt.Extensions.AwsSignature4.md
+++ b/.docfx/api/namespaces/Codebelt.Extensions.AwsSignature4.md
@@ -19,8 +19,8 @@ Complements: [AWS Signature Version 4](https://docs.aws.amazon.com/general/lates
 In this example we create an HTTP request with an AWS Signature Version 4 header. The example used here is part of the unit test for `Aws4HmacAuthorizationHeaderBuilder`. Unit test is based on [xUnit API](https://xunit.net/) and is written using convenient [extensions for xUnit API by Codebelt](https://github.com/codebeltnet/xunit).
 
 ```csharp
-using var host = WebHostTestFactory.Create();
-var context = host.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+using var test = WebHostTestFactory.Create();
+var context = test.Host.Services.GetRequiredService<IHttpContextAccessor>().HttpContext;
 
 var timestamp = DateTime.Parse("2022-07-10T12:50:42.2737531Z"); // <-- change this to valid date/time
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -18,10 +18,13 @@ on:
           - Debug
           - Release
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 🛠️ Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -63,7 +66,7 @@ jobs:
 
   pack:
     name: 📦 Pack
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -88,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-24.04, windows-2022]
         configuration: [Debug, Release]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -111,97 +114,41 @@ jobs:
           buildSwitches: -p:SkipSignAssembly=true
 
   sonarcloud:
-    name: 🔬 Code Quality Analysis
+    name: call-sonarcloud
     needs: [build,test]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
+    uses: codebeltnet/jobs-sonarcloud/.github/workflows/default.yml@v1
+    with:
+      organization: geekle
+      projectKey: aws-signature-v4
+      version: ${{ needs.build.outputs.version }}
+    secrets: inherit
 
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Install .NET Tool - Sonar Scanner
-        uses: codebeltnet/dotnet-tool-install-sonarscanner@v1
-
-      - name: Restore Dependencies
-        uses: codebeltnet/dotnet-restore@v2
-
-      - name: Run SonarCloud Analysis
-        uses: codebeltnet/sonarcloud-scan@v1
-        with:
-          token: ${{ secrets.SONAR_TOKEN }}
-          organization: geekle
-          projectKey: aws-signature-v4
-          version: ${{ needs.build.outputs.version }}
-
-      - name: Build
-        uses: codebeltnet/dotnet-build@v2
-        with:
-          buildSwitches: -p:SkipSignAssembly=true
-          uploadBuildArtifact: false
-
-      - name: Finalize SonarCloud Analysis
-        uses: codebeltnet/sonarcloud-scan-finalize@v1
-        with:
-          token: ${{ secrets.SONAR_TOKEN }}
 
   codecov:
-    name: 📊 Code Coverage Analysis
+    name: call-codecov
     needs: [build,test]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Run CodeCov Analysis
-        uses: codebeltnet/codecov-scan@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          repository: codebeltnet/aws-signature-v4
+    uses: codebeltnet/jobs-codecov/.github/workflows/default.yml@v1
+    with:
+      repository: codebeltnet/aws-signature-v4
+    secrets: inherit
           
   codeql:
-    name: 🛡️ Security Analysis
+    name: call-codeql
     needs: [build,test]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: codebeltnet/git-checkout@v1
-
-      - name: Install .NET
-        uses: codebeltnet/install-dotnet@v1
-        with:
-          includePreview: true
-
-      - name: Restore Dependencies
-        uses: codebeltnet/dotnet-restore@v2
-
-      - name: Prepare CodeQL SAST Analysis
-        uses: codebeltnet/codeql-scan@v1
-
-      - name: Build
-        uses: codebeltnet/dotnet-build@v2
-        with:
-          buildSwitches: -p:SkipSignAssembly=true
-          uploadBuildArtifact: false
-
-      - name: Finalize CodeQL SAST Analysis
-        uses: codebeltnet/codeql-scan-finalize@v1
+    uses: codebeltnet/jobs-codeql/.github/workflows/default.yml@v1
+    permissions:
+      security-events: write
 
   deploy:
     if: github.event_name != 'pull_request'
-    name: 🚀 Deploy v${{ needs.build.outputs.version }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    needs: [build, pack, test, sonarcloud, codecov, codeql]
-    environment: Production
-    steps:
-      - uses: codebeltnet/nuget-push@v1
-        with:
-          token: ${{ secrets.NUGET_TOKEN }}
-          configuration: ${{ inputs.configuration == '' && 'Release' || inputs.configuration }}
+    name: call-nuget
+    needs: [build,pack,test,sonarcloud,codecov,codeql]
+    uses: codebeltnet/jobs-nuget/.github/workflows/default.yml@v1
+    with:
+      version: ${{ needs.build.outputs.version }}
+      environment: Production
+      configuration: ${{ inputs.configuration == '' && 'Release' || inputs.configuration }}
+    permissions:
+      contents: write
+      packages: write
+    secrets: inherit

--- a/.nuget/Codebelt.Extensions.AwsSignature4/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Extensions.AwsSignature4/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 9.0.2
+Availability: .NET 9 and .NET 8 
+  
+# ALM 
+- CHANGED Dependencies to latest and greatest with respect to TFMs 
+  
 Version 9.0.1
 Availability: .NET 9 and .NET 8 
   

--- a/.nuget/Codebelt.Extensions.AwsSignature4/README.md
+++ b/.nuget/Codebelt.Extensions.AwsSignature4/README.md
@@ -17,8 +17,8 @@ More documentation available at our documentation site:
 In this example we create an HTTP request with an AWS Signature Version 4 header. The example used here is part of the unit test for `Aws4HmacAuthorizationHeaderBuilder`. Unit test is based on [xUnit API](https://xunit.net/) and is written using convenient [extensions for xUnit API by Codebelt](https://github.com/codebeltnet/xunit).
 
 ```csharp
-using var host = WebHostTestFactory.Create();
-var context = host.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+using var test = WebHostTestFactory.Create(); 
+var context = test.Host.Services.GetRequiredService<IHttpContextAccessor>().HttpContext; 
 
 var timestamp = DateTime.Parse("2022-07-10T12:50:42.2737531Z"); // <-- change this to valid date/time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 8.4.0 was migrated from previous versions of Cuemon.Extensions.AspNetCore.Authentication.AwsSignature4.
 
+## [9.0.2] - 2025-04-16
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.1] - 2025-01-31
 
 This is a service update that primarily focuses on package dependencies and minor improvements.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -67,7 +67,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.console" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.1.2" />
-    <PackageVersion Include="Cuemon.AspNetCore.Authentication" Version="9.0.3" />
-    <PackageVersion Include="Cuemon.Security.Cryptography" Version="9.0.3" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.0" />
+    <PackageVersion Include="Cuemon.AspNetCore.Authentication" Version="9.0.4" />
+    <PackageVersion Include="Cuemon.Security.Cryptography" Version="9.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,15 +3,15 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.0.1" />
-    <PackageVersion Include="Cuemon.AspNetCore.Authentication" Version="9.0.1" />
-    <PackageVersion Include="Cuemon.Security.Cryptography" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.1.2" />
+    <PackageVersion Include="Cuemon.AspNetCore.Authentication" Version="9.0.3" />
+    <PackageVersion Include="Cuemon.Security.Cryptography" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
 </Project>

--- a/test/Codebelt.Extensions.AwsSignature4.Test/Aws4HmacAuthorizationHeaderBuilderTest.cs
+++ b/test/Codebelt.Extensions.AwsSignature4.Test/Aws4HmacAuthorizationHeaderBuilderTest.cs
@@ -23,7 +23,7 @@ namespace Codebelt.Extensions.AwsSignature4
         [Fact]
         public void Build_ShouldGenerateValidAuthorizationHeader()
         {
-            using var host = WebHostTestFactory.Create();
+            using var host = WebHostTestFactory.Create(hostFixture: null);
             var context = host.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
 
             var timestamp = DateTime.Parse("2022-07-10T12:50:42.2737531Z", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind); // <-- change this to current date/time

--- a/test/Codebelt.Extensions.AwsSignature4.Test/Aws4HmacAuthorizationHeaderBuilderTest.cs
+++ b/test/Codebelt.Extensions.AwsSignature4.Test/Aws4HmacAuthorizationHeaderBuilderTest.cs
@@ -23,8 +23,8 @@ namespace Codebelt.Extensions.AwsSignature4
         [Fact]
         public void Build_ShouldGenerateValidAuthorizationHeader()
         {
-            using var host = WebHostTestFactory.Create(hostFixture: null);
-            var context = host.ServiceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+            using var test = WebHostTestFactory.Create();
+            var context = test.Host.Services.GetRequiredService<IHttpContextAccessor>().HttpContext;
 
             var timestamp = DateTime.Parse("2022-07-10T12:50:42.2737531Z", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind); // <-- change this to current date/time
 

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.407-9.0.202"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.408-9.0.203"
         }
     ]
 }

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -4,12 +4,12 @@
         {
             "name": "WSL-Ubuntu",
             "type": "wsl",
-            "wslDistribution": "Ubuntu-22.04"
+            "wslDistribution": "Ubuntu-24.04"
         },
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.405-9.0.102"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.407-9.0.202"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes several updates and improvements to dependencies, test configurations, and environment settings. The most important changes are categorized and listed below.

Dependency updates:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL70-R73): Updated `xunit.runner.visualstudio` package reference to include `PrivateAssets` and `IncludeAssets` attributes.
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L6-R15): Updated versions for multiple package references, including `Codebelt.Extensions.Xunit.App`, `Cuemon.AspNetCore.Authentication`, `Cuemon.Security.Cryptography`, `Microsoft.NET.Test.Sdk`, and `xunit.runner.visualstudio`.

Test configuration:

* [`test/Codebelt.Extensions.AwsSignature4.Test/Aws4HmacAuthorizationHeaderBuilderTest.cs`](diffhunk://#diff-cea093813fe50ff41f4861f0468594ba86c01dfa583a81e387697035f0bf1adaL26-R26): Modified the `Build_ShouldGenerateValidAuthorizationHeader` test to use `WebHostTestFactory.Create(hostFixture: null)`.

Environment settings:

* [`testenvironments.json`](diffhunk://#diff-9b8e96d74f58d1bbdcf7d7b724a15bd55082811dec8775f77cd16f909e898ec4L7-R12): Updated the `wslDistribution` to `Ubuntu-24.04` and the `dockerImage` to `gimlichael/ubuntu-testrunner:net8.0.407-9.0.202`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded several dependency packages to enhance overall stability and compatibility.
	- Updated configuration settings to use newer versions of software environments.
	- Improved CI/CD workflows by adopting reusable workflows and updating runner environments.
- **Tests**
	- Refined test initialization parameters for improved reliability during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->